### PR TITLE
Add new build number to correct master, which was merged by mistake.

### DIFF
--- a/FreteListTests/FreteListTests-Info.plist
+++ b/FreteListTests/FreteListTests-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>28</string>
+	<string>29</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationAlwaysUsageDescription</key>


### PR DESCRIPTION
This was done by checking out usability_fixes, which was the desired last commit. After that, changed only its build number to submit a new commit. Finally, merging it into master.
